### PR TITLE
[codex] Prepare v0.4 alpha API and demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,8 +159,9 @@ log levels are either `error`, `warn`, `info`, `debug`, or `trace`.
 
 - **circa 1994** — Core concept conceived 
 - **Aug 25, 2025** — Project started 
-- **Dec 25, 2025** — Source & web release (pre-alpha) ← *current* 
-- **Early 2026** — Demo scenario and tutorials
+- **Dec 25, 2025** — Source & web release (pre-alpha)
+- **Mar 2026** — v0.3.0 pre-alpha paper release
+- **May 2026** — v0.4.0 alpha preparation: consonance-first API and curated demos ← *current*
 - **Summer 2026** — Beta, featuring first compositions
 
 

--- a/docs/rhai_book/src/alpha_guide.md
+++ b/docs/rhai_book/src/alpha_guide.md
@@ -13,22 +13,22 @@ foundation that can later fuse with harmony.
 Run these scripts in order:
 
 ```bash
+cargo run --release -- samples/04_ecosystems/consonance_field_control.rhai
 cargo run --release -- samples/04_ecosystems/consonance_ecology.rhai
-cargo run --release -- samples/04_ecosystems/mirror_dualism.rhai
-cargo run --release -- samples/04_ecosystems/temporal_scaffolding_shared.rhai
+cargo run --release -- samples/04_ecosystems/pulse_foundation.rhai
 ```
+
+`consonance_field_control.rhai` is the first-pass harmony-control demo. Listen
+for the difference between root-centered Consonance Field placement, Consonance
+Density placement, active movement, and mirror changes.
 
 `consonance_ecology.rhai` is the flagship demo. Listen for a population that is
 not merely placed on a chord, but reorganizes as the consonance terrain, mirror,
 viability pressure, and respawn rules interact.
 
-`mirror_dualism.rhai` is a smaller field-control demo. Listen for how
-`set_harmonic_mirror()` bends the harmonic terrain and changes where new voices
-prefer to appear.
-
-`temporal_scaffolding_shared.rhai` is a rhythm-foundation demo. It is not the
-final rhythm/harmony fusion. Listen for a shared pulse that makes attack timing
-legible while the consonance ecology remains the main v0.4.0 focus.
+`pulse_foundation.rhai` is a rhythm-foundation sketch. It is not the final
+rhythm/harmony fusion. Listen for pulse articulation, gated durations,
+vitality-modulated coupling, and attack-phase reward.
 
 ## Core API Concepts
 

--- a/docs/rhai_book/src/alpha_guide.md
+++ b/docs/rhai_book/src/alpha_guide.md
@@ -45,6 +45,8 @@ glide defaults. Use `movement_glide(tau_sec)` when the musical thought is
 `consonance_viability(low, high)` defines the consonance window that feeds
 life-cycle viability. It defaults to environment-relative scoring, so a voice
 is evaluated against the field with its own footprint approximately removed.
+Use `viability_scope("total")` only when total-field viability is the intended
+comparison.
 
 `respawn_consonance()` lets a population replace itself through
 consonance-biased heredity. Combine it with `respawn_capacity(count)` and

--- a/docs/rhai_book/src/reference/life.md
+++ b/docs/rhai_book/src/reference/life.md
@@ -208,6 +208,7 @@ let decor = derive(sine).presentation_only();
 | `action_cost(cost)` | Energy cost per attack |
 | `viability_rate(rate)` | Environment-relative consonance recharge rate |
 | `consonance_viability(low, high)` | Consonance window used for viability |
+| `viability_scope(name)` | `"environment"` or `"total"` viability scoring scope |
 | `selection_approx_loo(enabled)` | Override environment-relative viability scoring for reference assays |
 | `dissonance_cost(cost)` | Extra energy cost at low consonance |
 | `adsr(attack_sec, decay_sec, sustain_level, release_sec)` | ADSR envelope |
@@ -220,12 +221,14 @@ let pluck = derive(harmonic)
     .action_cost(0.02)
     .viability_rate(0.2)
     .consonance_viability(0.3, 0.8)
+    .viability_scope("environment")
     .adsr(0.01, 0.1, 0.3, 0.2);
 ```
 
 `consonance_viability()` enables environment-relative scoring by default. Use
-`selection_approx_loo(false)` only when recreating older reference assays that
-need total-field selection.
+`viability_scope("total")` only when the selection question should include the
+voice's own contribution. `selection_approx_loo()` remains a research/reference
+control for older assays.
 
 ### Rhythm
 
@@ -418,7 +421,7 @@ Group methods work in two contexts:
 `repeat`, `once`, `pulse`, `while_alive`, `gates`, `field`, `sync`,
 `social`, `field_window`, `field_curve`, `field_drop`, `metabolism`,
 `initial_energy`, `recharge_rate`, `action_cost`, `viability_rate`,
-`consonance_viability`, `selection_approx_loo`, `dissonance_cost`,
+`consonance_viability`, `viability_scope`, `dissonance_cost`,
 `energy_cap`, `adsr`, `rhythm_coupling`, `rhythm_coupling_vitality`,
 `rhythm_reward`, `rhythm_freq`, `rhythm_sensitivity`, `k_omega`,
 `base_sigma`, `gate_thresholds`, `respawn_random`, `respawn_hereditary`,

--- a/docs/rhai_book/src/scripting_api.md
+++ b/docs/rhai_book/src/scripting_api.md
@@ -146,8 +146,11 @@ create(ecology, 14)
 wait(30.0);
 ```
 
+Use `viability_scope("total")` when the compositional question is explicitly
+total-field viability. The default `viability_scope("environment")` keeps
+v0.4.0 ecology centered on whether a voice is supported by its surroundings.
 Use `selection_approx_loo(false)` only for older reference assays that need the
-previous total-field selection condition.
+previous implementation-level control.
 
 ## Rhythm Foundation
 

--- a/docs/roadmap/v0.4.0-m1-api-decisions.md
+++ b/docs/roadmap/v0.4.0-m1-api-decisions.md
@@ -1,0 +1,65 @@
+# Conchordal v0.4.0 M1 API Decisions
+
+Status: Working note
+Scope: M1 consonance-first API inventory and vocabulary
+
+## Public v0.4.0 Concepts
+
+These names are the research-composer-facing vocabulary for v0.4.0:
+
+| Concept | Public Rhai names | Decision |
+|---|---|---|
+| Consonance Field placement | `consonance(root_hz)` | Keep as the root-centered field placement name. |
+| Consonance Density placement | `consonance_density(min_hz, max_hz)` | Keep distinct from field placement. |
+| Harmonic terrain control | `set_harmonic_mirror(value)` | Keep as the public mirror control. |
+| Consonance Movement | `consonance_movement()`, `movement_glide(tau_sec)` | Keep as the standard movement entrypoint and glide override. |
+| Consonance Viability | `consonance_viability(low, high)`, `viability_rate(rate)` | Keep as the public survival pressure vocabulary. |
+| Viability scope | `viability_scope("environment")`, `viability_scope("total")` | Add explicit semantic scope override. Default remains environment-relative. |
+| Consonance-biased replacement | `respawn_consonance()`, `respawn_capacity(count)`, `respawn_settle(strategy)` | Keep as ecology-scale replacement vocabulary. |
+| Routing roles | `field_only()`, `presentation_only()` | Keep as public world/presentation routing terms. |
+| Rhythm foundation | `repeat()`, `pulse(freq_hz)`, `gates(n)`, `rhythm_coupling_vitality(lambda_v, v_floor)`, `rhythm_reward(rho_t, "attack_phase_match")` | Document as foundation, not the release center. |
+
+## Research Controls
+
+These remain available, but curated v0.4.0 demos should not require them:
+
+| Area | Rhai names | Decision |
+|---|---|---|
+| Implementation-level self exclusion | `selection_approx_loo(enabled)`, `leave_self_out_mode(name)`, `leave_self_out_harmonics(count)` | Keep for reference assays and mechanism tests. Prefer `viability_scope(...)` in public prose. |
+| Low-level movement tuning | `pitch_mode`, `pitch_core`, `pitch_apply_mode`, `pitch_glide`, `global_peaks`, `ratio_candidates`, `move_cost`, `improvement_threshold`, `proposal_interval` | Keep as advanced controls. Use `consonance_movement()` first in curated demos. |
+| External rhythm scaffolds | `set_scaffold_off`, `set_scaffold_shared`, `set_scaffold_scrambled` | Keep as comparison controls, not the final rhythm-composition API. |
+| Detailed energy constants | `metabolism`, `initial_energy`, `energy_cap`, `action_cost`, `dissonance_cost` | Keep available; hide from first-path examples unless ecology behavior depends on them. |
+
+## Viability Scope Semantics
+
+`consonance_viability(low, high)` means environment-relative viability by
+default. This answers whether a voice is supported by its surroundings rather
+than by its own contribution to the field.
+
+Use:
+
+```rhai
+.viability_scope("environment")
+```
+
+for the default self-excluded counterfactual meaning.
+
+Use:
+
+```rhai
+.viability_scope("total")
+```
+
+only when the assay or composition intentionally includes the voice's own field
+contribution in the viability score.
+
+The live v0.4.0 implementation still uses the existing approximate LOO path for
+environment-relative scoring. That is an implementation detail, not the public
+composer-facing name.
+
+## Current M1 Rule
+
+If a name is needed to understand the flagship demos, document it as public. If
+it is needed to reproduce or inspect a mechanism, document it as research. Avoid
+adding compatibility aliases unless they remove real friction from the v0.4.0
+entry path.

--- a/docs/roadmap/v0.4.0-m1-api-decisions.md
+++ b/docs/roadmap/v0.4.0-m1-api-decisions.md
@@ -63,3 +63,20 @@ If a name is needed to understand the flagship demos, document it as public. If
 it is needed to reproduce or inspect a mechanism, document it as research. Avoid
 adding compatibility aliases unless they remove real friction from the v0.4.0
 entry path.
+
+## Audit Snapshot
+
+As of 2026-05-07, every Rhai name registered in
+`src/life/scripting/engine.rs` is present in
+`docs/rhai_book/src/reference/life.md` either as a preset, constructor, method,
+modifier, control-flow function, global setting, or research control.
+
+The current curated/reference sample split is:
+
+- v0.4 public prose and non-approx selection assays use `viability_scope(...)`
+  for the semantic scope.
+- `selection_approx_loo(...)` remains only for reference assays and
+  mechanism-level documentation.
+
+This satisfies the M1 reference-coverage criterion. The remaining M1 judgment
+work is naming/category review, not missing reference coverage.

--- a/samples/04_ecosystems/consonance_field_control.rhai
+++ b/samples/04_ecosystems/consonance_field_control.rhai
@@ -1,0 +1,73 @@
+// v0.4 harmony control demo.
+// Shows field placement, density placement, mirror modulation, and movement.
+
+seed(20260507);
+
+let root_hz = 130.81;
+let low_band = 90.0;
+let high_band = 1200.0;
+
+let anchor = derive(harmonic)
+    .brain("drone")
+    .amp(0.045)
+    .sustain()
+    .pitch_mode("lock")
+    .modes(harmonic_modes().count(8))
+    .brightness(0.28)
+    .sustain_drive(0.002)
+    .adsr(0.5, 1.1, 0.98, 2.4);
+
+let fixed_voice = derive(harmonic)
+    .amp(0.042)
+    .sustain()
+    .modes(harmonic_modes().count(6))
+    .brightness(0.34)
+    .adsr(0.35, 0.9, 0.86, 1.8);
+
+let mover = derive(harmonic)
+    .amp(0.038)
+    .sustain()
+    .consonance_movement()
+    .movement_glide(0.38)
+    .modes(harmonic_modes().count(7))
+    .brightness(0.44)
+    .crowding(0.45)
+    .leave_self_out_harmonics(3)
+    .global_peaks(8, 60.0)
+    .ratio_candidates(4)
+    .adsr(0.45, 1.0, 0.82, 1.9);
+
+scene("Consonance Field Control", || {
+    set_control_update_mode("snapshot_phased");
+    set_harmonic_mirror(0.0);
+
+    let root = create(anchor, 1).freq(root_hz);
+    wait(5.0);
+
+    let field_group = create(fixed_voice, 4)
+        .place(consonance(root_hz).range(1.0, 3.0).min_dist(0.9));
+    wait(10.0);
+
+    let density_group = create(mover, 5)
+        .place(consonance_density(low_band, high_band).min_dist(0.85));
+    wait(9.0);
+
+    set_harmonic_mirror(0.55);
+    root.freq(root_hz * 1.25);
+    density_group.movement_glide(0.28);
+    wait(10.0);
+
+    set_harmonic_mirror(1.0);
+    let high_group = create(derive(mover).amp(0.032).brightness(0.62), 4)
+        .place(consonance_density(150.0, 1500.0).min_dist(0.75));
+    wait(9.0);
+
+    release(field_group);
+    wait(1.0);
+    release(density_group);
+    wait(1.0);
+    release(high_group);
+    wait(1.0);
+    release(root);
+    wait(4.0);
+});

--- a/samples/04_ecosystems/hereditary_adaptation_heredity_selection.rhai
+++ b/samples/04_ecosystems/hereditary_adaptation_heredity_selection.rhai
@@ -63,7 +63,7 @@ let heredity_selection = derive(assay_voice)
     .viability_rate(0.12 * audition_speedup)
     .consonance_viability(0.30, 0.80)
     .dissonance_cost(1.0)
-    .selection_approx_loo(false)
+    .viability_scope("total")
     .respawn_consonance()
     .respawn_capacity(16);
 

--- a/samples/04_ecosystems/hereditary_adaptation_random_selection.rhai
+++ b/samples/04_ecosystems/hereditary_adaptation_random_selection.rhai
@@ -63,7 +63,7 @@ let random_selection = derive(assay_voice)
     .viability_rate(0.12 * audition_speedup)
     .consonance_viability(0.30, 0.80)
     .dissonance_cost(1.0)
-    .selection_approx_loo(false)
+    .viability_scope("total")
     .respawn_random()
     .respawn_capacity(16);
 

--- a/samples/04_ecosystems/pulse_foundation.rhai
+++ b/samples/04_ecosystems/pulse_foundation.rhai
@@ -1,0 +1,84 @@
+// v0.4 rhythm foundation sketch.
+// Uses pulse articulation, gated duration, vitality coupling, and phase reward.
+
+seed(20260507);
+
+let root_hz = 220.0;
+let pulse_hz = 2.0;
+
+let field_anchor = derive(harmonic)
+    .brain("drone")
+    .amp(0.040)
+    .sustain()
+    .pitch_mode("lock")
+    .modes(harmonic_modes().count(7))
+    .brightness(0.24)
+    .sustain_drive(0.0015)
+    .adsr(0.4, 0.9, 0.97, 1.8);
+
+let clock_voice = derive(sine)
+    .amp(0.030)
+    .repeat()
+    .pulse(pulse_hz)
+    .gates(1)
+    .pitch_mode("lock")
+    .adsr(0.01, 0.08, 0.55, 0.18);
+
+let follower = derive(harmonic)
+    .amp(0.050)
+    .repeat()
+    .pulse(pulse_hz)
+    .gates(3)
+    .rhythm_freq(pulse_hz)
+    .rhythm_coupling_vitality(0.85, 0.35)
+    .rhythm_reward(0.70, "attack_phase_match")
+    .consonance_movement()
+    .movement_glide(0.32)
+    .modes(harmonic_modes().count(6))
+    .brightness(0.36)
+    .crowding(0.40)
+    .initial_energy(0.70)
+    .energy_cap(0.90)
+    .metabolism(0.035)
+    .action_cost(0.010)
+    .adsr(0.04, 0.14, 0.90, 0.62);
+
+scene("Pulse Foundation", || {
+    set_control_update_mode("snapshot_phased");
+    set_harmonic_mirror(0.15);
+
+    let drone = create(field_anchor, 1).freq(root_hz);
+    wait(2.0);
+
+    let clock = create(clock_voice, 1).freq(root_hz * 2.0);
+    wait(4.0);
+
+    let followers = create(follower, 9)
+        .place(consonance_density(110.0, 880.0).min_dist(0.8));
+    wait(16.0);
+
+    set_harmonic_mirror(0.65);
+    drone.freq(root_hz * 1.5);
+    followers.movement_glide(0.24);
+    wait(14.0);
+
+    let cross_pulse = create(
+        derive(follower)
+            .amp(0.034)
+            .pulse(pulse_hz * 1.5)
+            .rhythm_freq(pulse_hz * 1.5)
+            .gates(2),
+        5,
+    )
+        .place(consonance_density(220.0, 1320.0).min_dist(0.7));
+    wait(10.0);
+
+    release(cross_pulse);
+    wait(1.2);
+    release(followers);
+    wait(1.4);
+    release(clock);
+    wait(0.8);
+    release(drone);
+    wait(3.0);
+});

--- a/src/life/scripting/engine.rs
+++ b/src/life/scripting/engine.rs
@@ -356,6 +356,13 @@ impl ScriptHost {
             SpeciesSpec::set_consonance_viability,
         );
         engine.register_fn(
+            "viability_scope",
+            |mut species: SpeciesHandle, name: &str| {
+                species.spec.set_viability_scope(name);
+                species
+            },
+        );
+        engine.register_fn(
             "selection_approx_loo",
             |mut species: SpeciesHandle, enabled: bool| {
                 species.spec.set_selection_approx_loo(enabled);
@@ -1602,6 +1609,8 @@ impl ScriptHost {
             "consonance_viability",
             SpeciesSpec::set_consonance_viability,
         );
+        register_group_draft_fn1!("viability_scope", ctx, engine, |s, name: &str| s
+            .set_viability_scope(name));
         register_group_draft_numeric_overloads(
             &mut engine,
             ctx.clone(),

--- a/src/life/scripting/mod.rs
+++ b/src/life/scripting/mod.rs
@@ -568,6 +568,17 @@ impl SpeciesSpec {
         self.selection_approx_loo = true;
     }
 
+    fn set_viability_scope(&mut self, name: &str) {
+        match name.trim().to_ascii_lowercase().as_str() {
+            "environment" => self.selection_approx_loo = true,
+            "total" => self.selection_approx_loo = false,
+            other => warn!(
+                "viability_scope() expects 'environment' or 'total', got '{}'",
+                other
+            ),
+        }
+    }
+
     fn set_selection_approx_loo(&mut self, enabled: bool) {
         self.selection_approx_loo = enabled;
     }

--- a/src/life/scripting/tests.rs
+++ b/src/life/scripting/tests.rs
@@ -1705,6 +1705,75 @@ fn selection_approx_loo_can_override_consonance_viability_for_reference_assays()
 }
 
 #[test]
+fn viability_scope_total_overrides_environment_default() {
+    let (scenario, _warnings) = run_script(
+        r#"
+            create(
+                harmonic
+                    .metabolism(0.1)
+                    .consonance_viability(0.3, 0.8)
+                    .viability_scope("total"),
+                1
+            );
+            flush();
+        "#,
+    );
+    let spawn = scenario
+        .events
+        .iter()
+        .flat_map(|event| &event.actions)
+        .find_map(|action| match action {
+            Action::Spawn { spec, .. } => Some(spec.clone()),
+            _ => None,
+        })
+        .expect("spawn action");
+    let ArticulationCoreConfig::Entrain { lifecycle, .. } = spawn.articulation else {
+        panic!("expected entrain articulation");
+    };
+    let LifecycleConfig::Sustain {
+        selection_approx_loo,
+        ..
+    } = lifecycle
+    else {
+        panic!("expected sustain lifecycle");
+    };
+    assert!(!selection_approx_loo);
+}
+
+#[test]
+fn draft_group_viability_scope_total_overrides_environment_default() {
+    let (scenario, _warnings) = run_script(
+        r#"
+            create(harmonic, 1)
+                .metabolism(0.1)
+                .consonance_viability(0.3, 0.8)
+                .viability_scope("total");
+            flush();
+        "#,
+    );
+    let spawn = scenario
+        .events
+        .iter()
+        .flat_map(|event| &event.actions)
+        .find_map(|action| match action {
+            Action::Spawn { spec, .. } => Some(spec.clone()),
+            _ => None,
+        })
+        .expect("spawn action");
+    let ArticulationCoreConfig::Entrain { lifecycle, .. } = spawn.articulation else {
+        panic!("expected entrain articulation");
+    };
+    let LifecycleConfig::Sustain {
+        selection_approx_loo,
+        ..
+    } = lifecycle
+    else {
+        panic!("expected sustain lifecycle");
+    };
+    assert!(!selection_approx_loo);
+}
+
+#[test]
 fn live_group_brightness_emits_timbre_patch() {
     let (scenario, _warnings) = run_script(
         r#"

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -148,13 +148,13 @@
                 <span class="roadmap-date">Dec 2025</span>
                 <span class="roadmap-text">v0.1.0 source & web release (pre-alpha)</span>
             </div>
-            <div class="roadmap-item current">
+            <div class="roadmap-item">
                 <span class="roadmap-date">Mar 2026</span>
                 <span class="roadmap-text">v0.3.0 pre-alpha — <a href="https://arxiv.org/abs/2603.25637">paper on arXiv</a></span>
             </div>
-            <div class="roadmap-item future">
-                <span class="roadmap-date">Spring 2026</span>
-                <span class="roadmap-text">v0.4.0 alpha — first fully functional release</span>
+            <div class="roadmap-item current">
+                <span class="roadmap-date">May 2026</span>
+                <span class="roadmap-text">v0.4.0 alpha preparation — consonance-first API and curated demos</span>
             </div>
             <div class="roadmap-item future">
                 <span class="roadmap-date">Summer 2026</span>


### PR DESCRIPTION
## Summary

- Adds `viability_scope("environment" | "total")` as the public semantic control for consonance viability scope.
- Records the M1 Rhai API audit and public/research vocabulary split.
- Adds curated v0.4 alpha demos: `consonance_field_control.rhai` and `pulse_foundation.rhai`.
- Updates the Alpha Guide run path plus README/web roadmap status for v0.4 alpha preparation.

## Impact

This moves the release path from implementation-oriented LOO naming toward the v0.4 research-composer vocabulary, while keeping `selection_approx_loo(...)` available for reference assays.

## Validation

- `cargo clippy -- -D warnings`
- `cargo test -q compile_only_samples_tests -- --nocapture`
- `cargo test -q run_headless_scripts -- --nocapture`
- `cargo test -q samples_have_no_legacy_keys -- --nocapture`
- `zola build`
- `mdbook build docs/rhai_book`
- `RUST_BACKTRACE=1 cargo test -- --nocapture` -> `exit=0 @ 2026-05-07T11:37:43+09:00`
